### PR TITLE
Support formatting behavior of underlying console.log.

### DIFF
--- a/lib/clog.js
+++ b/lib/clog.js
@@ -119,14 +119,14 @@ Clog.prototype.configure = function (config) {
  * Log method.
  */
 
-Clog.prototype.log = function (type) {
-
+Clog.prototype.log = function (type, msg) {
+  var msgIsString = typeof (msg) == 'string';
   levels[type] !== false && console.log.apply(
       console
     , [colors[type]
-        ? '\033[' + colors[type] + 'm' + type + ':\033[39m'
-        : '\033[37m' + type + ':\033[39m'
-      ].concat(toArray(arguments).slice(1))
+        ? '\033[' + colors[type] + 'm' + type + ':\033[39m ' + (msgIsString ? msg : '')
+        : '\033[37m' + type + ':\033[39m ' + (msgIsString ? msg : '')
+      ].concat(toArray(arguments).slice(msgIsString ? 2 : 1))
   );
 
   return levels[type];


### PR DESCRIPTION
support console.log formatting behavior by concatenating the second argument (the 'format string') to the colorized type prefix, if the second argument is a string. if the second argument is not a string, it remains in the subsequent array of arguments, as it currently behaves.
